### PR TITLE
Revert "fix(deps): update dependency @livekit/agents to ^0.6.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "@livekit/agents": "^0.6.0",
+    "@livekit/agents": "^0.4.5",
     "@livekit/agents-plugin-openai": "^0.6.0",
     "dotenv": "^16.4.5",
     "zod": "^3.23.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@livekit/agents':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.4.5
+        version: 0.4.5(@livekit/rtc-node@0.11.1)
       '@livekit/agents-plugin-openai':
         specifier: ^0.6.0
-        version: 0.6.0(@livekit/agents@0.6.0)(zod@3.23.8)
+        version: 0.6.0(@livekit/agents@0.4.5(@livekit/rtc-node@0.11.1))(@livekit/rtc-node@0.11.1)(zod@3.23.8)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -113,6 +113,9 @@ packages:
 
   '@bufbuild/protobuf@1.10.0':
     resolution: {integrity: sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==}
+
+  '@bufbuild/protobuf@2.2.2':
+    resolution: {integrity: sha512-UNtPCbrwrenpmrXuRwn9jYpPoweNXj8X5sMvYgsqYyaH8jQ6LfUJSk3dJLnBK+6sfYPrF4iAIo5sd5HQ+tg75A==}
 
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
@@ -285,16 +288,50 @@ packages:
       '@livekit/agents': ^0.4.5
       '@livekit/rtc-node': ^0.11.1
 
-  '@livekit/agents@0.6.0':
-    resolution: {integrity: sha512-xjfJRYepU2kdCcCdbstYFg0LtXLDQhgN+9yC68P4LVg8bBjfv+8hZDUgRnA2HVAib2rpypVTR3pqKWWCLSwzIg==}
+  '@livekit/agents@0.4.5':
+    resolution: {integrity: sha512-4oza+tnUO42nk8AWOOhVV1SwcqCu2qBMeOJ4wbRRrjoOWl3Hf6gVA+hNKq7IjZqej4f6cp+drksOoKzzAaV3fw==}
     peerDependencies:
-      '@livekit/rtc-node': ^0.12.1
+      '@livekit/rtc-node': ^0.11.1
 
-  '@livekit/mutex@1.1.1':
-    resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
+  '@livekit/mutex@1.1.0':
+    resolution: {integrity: sha512-XRLG+z/0uoyDioupjUiskjI06Y51U/IXVPJn7qJ+R3J75XX01irYVBM9MpxeJahpVoe9QhU4moIEolX+HO9U9g==}
 
-  '@livekit/protocol@1.29.4':
-    resolution: {integrity: sha512-dsqxvABHilrMA0BU5m1w8cMWSVeDjV2ZUIUDClNQZju3c30DLMfEYDHU5nmXDfaaHjNIgoRbYR7upJMozG8JJg==}
+  '@livekit/protocol@1.27.1':
+    resolution: {integrity: sha512-ISEp7uWdV82mtCR1eyHFTzdRZTVbe2+ZztjmjiMPzR/KPrI1Ma/u5kLh87NNuY3Rn8wv1VlEvGHHsFjQ+dKVUw==}
+
+  '@livekit/rtc-node-darwin-arm64@0.11.1':
+    resolution: {integrity: sha512-M+Ui87H06ae19GGI7r937dS6hI84MBBTQAkkNlL7qd+pvdCAk25u0FYa8r4SOElKJ0VR3AbzeDoXTihLgpvjMg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@livekit/rtc-node-darwin-x64@0.11.1':
+    resolution: {integrity: sha512-7G92fyuK2p+jdTH2cUJTNeAmtknTGsXuy0xbI727V7VzQvHFDXULCExRlgwn4t9TxvNlIjUpiltiQ6RCSai6zw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@livekit/rtc-node-linux-arm64-gnu@0.11.1':
+    resolution: {integrity: sha512-vqZN9+87Pvxit7auYVW69M+GvUPnf+EwipIJ92GgCJA3Ir1Tcceu5ud5/Ic+0FzSoV0cotVVlQNm74F0tQvyCg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@livekit/rtc-node-linux-x64-gnu@0.11.1':
+    resolution: {integrity: sha512-smHZUMfgILQh6/eoauYNe/VlKwQCp4/4jWxiIADHY+mtDtVSvQ9zB6y4GP8FrpohRwFWesKCUpvPBypU0Icrng==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@livekit/rtc-node-win32-x64-msvc@0.11.1':
+    resolution: {integrity: sha512-bTWVtb+UiRPFjiuhrqq40gt5vs5mMPTa1e+kd2jGQPTOlKZPLArQ0WgFcep2TAy1zmcpOgfeM1XRPVFhZl7G1A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@livekit/rtc-node@0.11.1':
+    resolution: {integrity: sha512-EFw+giPll12fcXATZpN2zKkE3umYJAdHvfjW+Yu0aBjwfxbUBXu8rz6le2CzDNvGmRwR888DSZXFZfYikwZgiw==}
+    engines: {node: '>= 18'}
 
   '@livekit/typed-emitter@3.0.0':
     resolution: {integrity: sha512-9bl0k4MgBPZu3Qu3R3xy12rmbW17e3bE9yf4YY85gJIQ3ezLEj/uzpKHWBsLaDoL5Mozz8QCgggwIBudYQWeQg==}
@@ -1069,9 +1106,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  livekit-server-sdk@2.9.4:
-    resolution: {integrity: sha512-SD0ZokI6Jdx8eneV76ZyC3qOpbWiA4aKCHnMRnJGrTx+MNiebhntvxHUDAecx2EbxkcbFQZPEfw+P9QWHbLjTQ==}
-    engines: {node: '>=18'}
+  livekit-server-sdk@2.8.1:
+    resolution: {integrity: sha512-l8egXU10jPuRJM2Df9Gk/KPEk6tBV0JEGG19cD5QeQtyIMgqULCCd/5yyG2FRvcWRf7pEyZZMXi63zDn7uaKHQ==}
+    engines: {node: '>=19'}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -1608,6 +1645,8 @@ snapshots:
 
   '@bufbuild/protobuf@1.10.0': {}
 
+  '@bufbuild/protobuf@2.2.2': {}
+
   '@emnapi/runtime@1.3.1':
     dependencies:
       tslib: 2.8.1
@@ -1756,9 +1795,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@livekit/agents-plugin-openai@0.6.0(@livekit/agents@0.6.0)(zod@3.23.8)':
+  '@livekit/agents-plugin-openai@0.6.0(@livekit/agents@0.4.5(@livekit/rtc-node@0.11.1))(@livekit/rtc-node@0.11.1)(zod@3.23.8)':
     dependencies:
-      '@livekit/agents': 0.6.0
+      '@livekit/agents': 0.4.5(@livekit/rtc-node@0.11.1)
+      '@livekit/rtc-node': 0.11.1
       openai: 4.73.0(zod@3.23.8)
       sharp: 0.33.5
       ws: 8.18.0
@@ -1768,13 +1808,14 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@livekit/agents@0.6.0':
+  '@livekit/agents@0.4.5(@livekit/rtc-node@0.11.1)':
     dependencies:
-      '@livekit/mutex': 1.1.1
-      '@livekit/protocol': 1.29.4
+      '@livekit/mutex': 1.1.0
+      '@livekit/protocol': 1.27.1
+      '@livekit/rtc-node': 0.11.1
       '@livekit/typed-emitter': 3.0.0
       commander: 12.1.0
-      livekit-server-sdk: 2.9.4
+      livekit-server-sdk: 2.8.1
       pino: 8.21.0
       pino-pretty: 11.3.0
       ws: 8.18.0
@@ -1783,11 +1824,38 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@livekit/mutex@1.1.1': {}
+  '@livekit/mutex@1.1.0': {}
 
-  '@livekit/protocol@1.29.4':
+  '@livekit/protocol@1.27.1':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
+
+  '@livekit/rtc-node-darwin-arm64@0.11.1':
+    optional: true
+
+  '@livekit/rtc-node-darwin-x64@0.11.1':
+    optional: true
+
+  '@livekit/rtc-node-linux-arm64-gnu@0.11.1':
+    optional: true
+
+  '@livekit/rtc-node-linux-x64-gnu@0.11.1':
+    optional: true
+
+  '@livekit/rtc-node-win32-x64-msvc@0.11.1':
+    optional: true
+
+  '@livekit/rtc-node@0.11.1':
+    dependencies:
+      '@bufbuild/protobuf': 2.2.2
+      '@livekit/mutex': 1.1.0
+      '@livekit/typed-emitter': 3.0.0
+    optionalDependencies:
+      '@livekit/rtc-node-darwin-arm64': 0.11.1
+      '@livekit/rtc-node-darwin-x64': 0.11.1
+      '@livekit/rtc-node-linux-arm64-gnu': 0.11.1
+      '@livekit/rtc-node-linux-x64-gnu': 0.11.1
+      '@livekit/rtc-node-win32-x64-msvc': 0.11.1
 
   '@livekit/typed-emitter@3.0.0': {}
 
@@ -2672,9 +2740,9 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  livekit-server-sdk@2.9.4:
+  livekit-server-sdk@2.8.1:
     dependencies:
-      '@livekit/protocol': 1.29.4
+      '@livekit/protocol': 1.27.1
       camelcase-keys: 9.1.3
       jose: 5.9.6
 


### PR DESCRIPTION
Reverts livekit-examples/multimodal-agent-node#32, as it introduced some dependency issues that cause a runtime crash on attempt to import `@livekit/rtc-node`:

```
> node dist/agent.js dev
node:internal/modules/esm/resolve:841
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
        ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@livekit/rtc-node' imported from /Volumes/Samsung/Download/multimodal-agent-node/node_modules/.pnpm/@livekit+agents@0.6.0/node_modules/@livekit/agents/dist/job.js
    at packageResolve (node:internal/modules/esm/resolve:841:9)
    at moduleResolve (node:internal/modules/esm/resolve:914:18)
    at defaultResolve (node:internal/modules/esm/resolve:1119:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:541:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:510:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:240:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:126:49) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```